### PR TITLE
Migrate editing, polling and resizing functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
 {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
+        "source.fixAll.eslint": "explicit",
+        "source.organizeImports": "explicit"
     },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,10 +5,10 @@
  * terms of the MIT License as outlined in the LICENSE file.
  **********************************************************************************/
 
-import globals from 'globals';
 import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
 import header from 'eslint-plugin-header';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 header.rules.header.meta.schema = false;
 
@@ -32,13 +32,7 @@ export default tseslint.config(
             // ESLint Convention
             quotes: ['error', 'single'],
             semi: ['error', 'always'],
-            indent: [
-                'error',
-                4,
-                {
-                    SwitchCase: 1
-                }
-            ],
+
             'block-spacing': ['error', 'always'],
             'brace-style': [
                 'error',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "antd": "^5.22.1",
         "primeflex": "^3.3.1",
+        "re-resizable": "^6.11.2",
         "react-markdown": "^9.0.1",
         "remark-gfm": "^4.0.0",
         "throttle-debounce": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "@vscode/codicons": "0.0.20",
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "antd": "^5.22.1",
-        "primeflex": "^3.3.1",
         "re-resizable": "^6.11.2",
         "react-markdown": "^9.0.1",
         "remark-gfm": "^4.0.0",

--- a/src/base/style-utils.ts
+++ b/src/base/style-utils.ts
@@ -1,21 +1,23 @@
 /**********************************************************************************
- * Copyright (c) 2025 Company and others.
+ * Copyright (c) 2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License as outlined in the LICENSE file.
  **********************************************************************************/
 
-export function classNames(...classes: (string | Record<string, boolean>)[]): string {
+export function classNames(...classes: (string | Record<string, boolean> | undefined)[]): string {
     return classes
-        .filter(c => c !== undefined)
-        .map(c => {
-            if (typeof c === 'string') {
-                return c;
+        .map(className => {
+            if (!className) {
+                return '';
             }
-
-            return Object.entries(c)
+            if (typeof className === 'string') {
+                return className;
+            }
+            return Object.entries(className)
                 .filter(([, value]) => value)
                 .map(([key]) => key);
         })
+        .filter(className => className.length > 0)
         .join(' ');
 }

--- a/src/label/label-helpers.tsx
+++ b/src/label/label-helpers.tsx
@@ -48,7 +48,7 @@ export function createHighlightedText(label?: string, highlights?: [number, numb
 }
 
 export function createLabelWithTooltip(child: React.JSX.Element, tooltip?: string): React.JSX.Element {
-    const label = <div className='tree-label flex-auto flex align-items-center'>{child}</div>;
+    const label = <div className='tree-label'>{child}</div>;
 
     if (tooltip === undefined) {
         return label;

--- a/src/label/label-helpers.tsx
+++ b/src/label/label-helpers.tsx
@@ -1,5 +1,5 @@
 /**********************************************************************************
- * Copyright (c) 2025 Company and others.
+ * Copyright (c) 2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License as outlined in the LICENSE file.
@@ -8,7 +8,7 @@
 import React from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Tooltip, TooltipTrigger, TooltipContent } from '../tooltip/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../tooltip/tooltip';
 
 export function createHighlightedText(label?: string, highlights?: [number, number][]): React.JSX.Element {
     if (label === undefined) {

--- a/src/tree/browser/components/cells/ActionCell.tsx
+++ b/src/tree/browser/components/cells/ActionCell.tsx
@@ -1,0 +1,44 @@
+/**********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
+
+import React from 'react';
+import { CommandDefinition } from '../../../../vscode/webview-types';
+import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableActionColumn, CDTTreeTableActionColumnCommand } from '../../../common';
+
+export interface ActionCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableActionColumn;
+    record: CDTTreeItem<T>;
+    actions: CDTTreeTableActionColumnCommand[];
+    onAction?: (event: React.UIEvent, command: CommandDefinition, value: unknown, record: CDTTreeItem<T>) => void;
+}
+
+const ActionCell = <T extends CDTTreeItemResource>({ record, actions, onAction }: ActionCellProps<T>) => {
+    return (
+        <div className='tree-actions'>
+            {actions.map(action => {
+                const handleAction = (e: React.MouseEvent | React.KeyboardEvent) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onAction?.(e, action, action.value, record);
+                };
+                return (
+                    <i
+                        key={action.commandId}
+                        title={action.title}
+                        className={`codicon codicon-${action.icon}`}
+                        onClick={handleAction}
+                        role='button'
+                        tabIndex={0}
+                        onKeyDown={e => e.key === 'Enter' && handleAction(e)}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+export default ActionCell;

--- a/src/tree/browser/components/cells/EditableStringCell.tsx
+++ b/src/tree/browser/components/cells/EditableStringCell.tsx
@@ -1,0 +1,157 @@
+/**********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
+
+import '../../../../../style/tree/editable-string-cell.css';
+
+import { Checkbox, Input, Select } from 'antd';
+import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { CDTTreeItem, CDTTreeItemResource, EditableCDTTreeTableStringColumn } from '../../../common';
+import LabelCell from './LabelCell';
+
+interface EditableLabelCellProps<T extends CDTTreeItemResource> {
+    column: EditableCDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+    editing: boolean;
+    autoFocus: boolean;
+    onSubmit: (newValue: string) => void;
+    onCancel: () => void;
+    onEdit?: (edit: boolean) => void;
+}
+
+const EditableLabelCell = <T extends CDTTreeItemResource>({
+    column,
+    record,
+    editing,
+    autoFocus,
+    onSubmit,
+    onCancel,
+    onEdit
+}: EditableLabelCellProps<T>) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editorRef = useRef<any>(null);
+
+    const commitEdit = useCallback(
+        (newValue: string, event?: { stopPropagation: () => void; preventDefault: () => void }) => {
+            event?.stopPropagation();
+            event?.preventDefault();
+            onSubmit(newValue);
+            onEdit?.(false);
+        },
+        [onSubmit]
+    );
+
+    const cancelEdit = useCallback(() => {
+        onCancel();
+        onEdit?.(false);
+    }, [column.edit.value, onCancel, onEdit]);
+
+    // Cancel the edit only if focus leaves the entire container.
+    const handleBlur = useCallback(() => {
+        setTimeout(() => {
+            if (containerRef.current && document.activeElement && !containerRef.current.contains(document.activeElement)) {
+                cancelEdit();
+            }
+        }, 0);
+    }, [cancelEdit]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                cancelEdit();
+            }
+            e.stopPropagation();
+        },
+        [cancelEdit]
+    );
+
+    // Consume the double-click event so no other handler is triggered.
+    const handleDoubleClick = useCallback(
+        (e: React.MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onEdit?.(true);
+        },
+        [column, onEdit]
+    );
+
+    // Focus the editor when entering edit mode.
+    useEffect(() => {
+        if (editing && editorRef.current && autoFocus) {
+            editorRef.current.focus();
+        }
+    }, [editing, autoFocus]);
+
+    if (editing) {
+        return (
+            <div className='edit-field-container' ref={containerRef}>
+                {(() => {
+                    switch (column.edit.type) {
+                        case 'text':
+                            return (
+                                <Input
+                                    ref={editorRef}
+                                    className={'text-field-cell'}
+                                    defaultValue={column.edit.value}
+                                    onPressEnter={e => commitEdit(e.currentTarget.value, e)}
+                                    onBlur={handleBlur}
+                                    onClick={e => e.stopPropagation()}
+                                    onKeyDown={handleKeyDown}
+                                />
+                            );
+                        case 'boolean': {
+                            const checked = column.edit.value === '1';
+                            return (
+                                <Checkbox
+                                    ref={editorRef}
+                                    checked={checked}
+                                    onChange={(e: CheckboxChangeEvent) => commitEdit(e.target.checked ? '1' : '0', e)}
+                                    onBlur={handleBlur}
+                                    onClick={e => e.stopPropagation()}
+                                    onKeyDown={handleKeyDown}
+                                />
+                            );
+                        }
+                        case 'enum': {
+                            return (
+                                <Select
+                                    ref={editorRef}
+                                    className={'enum-field-cell'}
+                                    placeholder={column.label}
+                                    value={column.label} // we want to use 'Write Only' as value even if it is not an option
+                                    onChange={newValue => commitEdit(newValue)}
+                                    onBlur={handleBlur}
+                                    onClick={e => e.stopPropagation()}
+                                    onKeyDown={handleKeyDown}
+                                >
+                                    {column.edit.options.map(opt => {
+                                        return (
+                                            <Select.Option key={opt.value} value={opt.value}>
+                                                {opt.label}
+                                            </Select.Option>
+                                        );
+                                    })}
+                                </Select>
+                            );
+                        }
+                        default:
+                            return null;
+                    }
+                })()}
+            </div>
+        );
+    }
+
+    return (
+        <div className='editable-string-cell' onDoubleClick={handleDoubleClick}>
+            <LabelCell record={record} column={column} />
+        </div>
+    );
+};
+
+export default React.memo(EditableLabelCell);

--- a/src/tree/browser/components/cells/LabelCell.tsx
+++ b/src/tree/browser/components/cells/LabelCell.tsx
@@ -1,0 +1,33 @@
+/**********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
+
+import classNames from 'classnames';
+import React from 'react';
+import { createHighlightedText, createLabelWithTooltip } from '../../../../label/label-helpers';
+import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableStringColumn } from '../../../common';
+
+export interface LabelCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+}
+
+const LabelCell = <T extends CDTTreeItemResource>({ column }: LabelCellProps<T>) => {
+    const icon = column.icon && <i className={classNames('cell-icon', column.icon)} />;
+
+    const content = column.tooltip
+        ? createLabelWithTooltip(<span>{createHighlightedText(column.label, column.highlight)}</span>, column.tooltip)
+        : createHighlightedText(column.label, column.highlight);
+
+    return (
+        <div className='tree-cell ant-table-cell-ellipsis' tabIndex={0}>
+            {icon}
+            {content}
+        </div>
+    );
+};
+
+export default React.memo(LabelCell);

--- a/src/tree/browser/components/cells/StringCell.tsx
+++ b/src/tree/browser/components/cells/StringCell.tsx
@@ -1,0 +1,53 @@
+/**********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
+
+import React, { useCallback } from 'react';
+import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableStringColumn, EditableCDTTreeTableStringColumn } from '../../../common';
+import EditableStringCell from './EditableStringCell';
+import LabelCell from './LabelCell';
+
+interface StringCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+    editing?: boolean;
+    autoFocus?: boolean;
+    onSubmit?: (record: CDTTreeItem<T>, newValue: string) => void;
+    onCancel?: (record: CDTTreeItem<T>) => void;
+    onEdit?: (record: CDTTreeItem<T>, edit: boolean) => void;
+}
+
+const StringCell = <T extends CDTTreeItemResource>({
+    column,
+    record,
+    editing = false,
+    autoFocus = false,
+    onSubmit,
+    onCancel,
+    onEdit
+}: StringCellProps<T>) => {
+    const handleSubmit = useCallback((newValue: string) => onSubmit?.(record, newValue), [record, onSubmit]);
+
+    const handleCancel = useCallback(() => onCancel?.(record), [record, onCancel]);
+
+    const handleEdit = useCallback((edit: boolean) => onEdit?.(record, edit), [record, onEdit]);
+
+    return column.edit && onSubmit ? (
+        <EditableStringCell
+            record={record}
+            column={column as EditableCDTTreeTableStringColumn}
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+            onEdit={handleEdit}
+            editing={editing}
+            autoFocus={autoFocus}
+        />
+    ) : (
+        <LabelCell record={record} column={column} />
+    );
+};
+
+export default StringCell;

--- a/src/tree/browser/components/expand-icon.tsx
+++ b/src/tree/browser/components/expand-icon.tsx
@@ -1,13 +1,13 @@
-/********************************************************************************
- * Copyright (C) 2024-2025 EclipseSource and others.
+/**********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
- * terms of the MIT License as outlined in the LICENSE File
- ********************************************************************************/
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
 
-import type { CDTTreeItemResource, CDTTreeItem } from '../../common/tree-model-types';
-import { classNames } from '../../../base';
 import React from 'react';
+import { classNames } from '../../../base';
+import { CDTTreeItem, CDTTreeItemResource } from '../../common';
 
 export interface RenderExpandIconProps<RecordType> {
     expanded: boolean;

--- a/src/tree/browser/components/treetable-navigator.tsx
+++ b/src/tree/browser/components/treetable-navigator.tsx
@@ -2,10 +2,10 @@
  * Copyright (C) 2024-2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
- * terms of the MIT License as outlined in the LICENSE File
- ********************************************************************************/
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
 
-import { CDTTreeItemResource, CDTTreeItem } from '../../common';
+import { CDTTreeItem, CDTTreeItemResource } from '../../common';
 
 export interface TreeNavigatorProps<T extends CDTTreeItemResource> {
     ref: React.RefObject<HTMLDivElement>;

--- a/src/tree/browser/tree.tsx
+++ b/src/tree/browser/tree.tsx
@@ -35,7 +35,7 @@ import { filterTree, getAncestors, traverseTree, useClickHook } from './componen
 const COLUMN_MIN_WIDTH = 50;
 const ACTION_COLUMN_WIDTH = 16 * 5;
 
-export interface PublicAPI {
+export interface CDTTreeApi {
     selectRow: (record: CDTTreeItem) => void;
     setEditRowKey: (key: string | undefined) => void;
 }
@@ -81,7 +81,7 @@ export type CDTTreeProps<T extends CDTTreeItemResource = CDTTreeItemResource> = 
         /**
          * Callback to be called when a row is pinned or unpinned.
          */
-        onPin?: (event: React.UIEvent, pinned: boolean, record: CDTTreeItem<T>, api: PublicAPI) => void;
+        onPin?: (event: React.UIEvent, pinned: boolean, record: CDTTreeItem<T>, api: CDTTreeApi) => void;
     };
     /**
      * Configuration for the actions of the tree table.
@@ -90,13 +90,13 @@ export type CDTTreeProps<T extends CDTTreeItemResource = CDTTreeItemResource> = 
         /**
          * Callback to be called when an action is triggered.
          */
-        onAction?: (event: React.UIEvent, command: CommandDefinition, value: unknown, record: CDTTreeItem<T>, api: PublicAPI) => void;
+        onAction?: (event: React.UIEvent, command: CommandDefinition, value: unknown, record: CDTTreeItem<T>, api: CDTTreeApi) => void;
     };
     edit?: {
         /**
          * Callback to be called when a row is edited.
          */
-        onEdit?: (record: CDTTreeItem<T>, value: string, api: PublicAPI) => void;
+        onEdit?: (record: CDTTreeItem<T>, value: string, api: CDTTreeApi) => void;
     };
 };
 
@@ -424,11 +424,11 @@ export const CDTTree = <T extends CDTTreeItemResource>(props: CDTTreeProps<T>) =
         (event: React.UIEvent, command: CommandDefinition, value: unknown, record: CDTTreeItem<T>) => {
             if (command.commandId === InternalCommands.PIN_ID || command.commandId === InternalCommands.UNPIN_ID) {
                 event.stopPropagation();
-                props.pin?.onPin?.(event, value as boolean, record, puplicAPI);
+                props.pin?.onPin?.(event, value as boolean, record, treeApi);
                 return;
             }
 
-            return props.action?.onAction?.(event, command, value, record, puplicAPI);
+            return props.action?.onAction?.(event, command, value, record, treeApi);
         },
         [props.action, props.pin?.onPin]
     );
@@ -447,7 +447,7 @@ export const CDTTree = <T extends CDTTreeItemResource>(props: CDTTreeProps<T>) =
     const onSubmitEdit = useCallback(
         (record: CDTTreeItem<T>, value: string) => {
             setEditRowKey(undefined);
-            props.edit?.onEdit?.(record, value, puplicAPI);
+            props.edit?.onEdit?.(record, value, treeApi);
         },
         [props.edit?.onEdit]
     );
@@ -608,7 +608,7 @@ export const CDTTree = <T extends CDTTreeItemResource>(props: CDTTreeProps<T>) =
 
     // ==== Return ====
 
-    const puplicAPI = useMemo<PublicAPI>(
+    const treeApi = useMemo<CDTTreeApi>(
         () => ({
             selectRow,
             setEditRowKey

--- a/src/tree/common/tree-converter.ts
+++ b/src/tree/common/tree-converter.ts
@@ -5,7 +5,7 @@
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
 
-import type { CDTTreeItemResource, CDTTreeItem } from './tree-model-types';
+import type { CDTTreeItem, CDTTreeItemResource } from './tree-model-types';
 
 /**
  * A TreeConverterContext is used to pass additional information to the TreeResourceConverter.
@@ -27,7 +27,11 @@ export interface CDTTreeConverterContext<TResource extends CDTTreeItemResource =
      * This can be useful to access parent resources.
      * It is filled while converting the tree.
      */
-    resourceMap: Map<string, TResource>;
+    assignedResources: Record<string, TResource | undefined>;
+    /**
+     * A map of all items that are currently in the tree.
+     */
+    assignedItems: Record<string, CDTTreeItem<TResource> | undefined>;
 }
 
 /**

--- a/src/tree/common/tree-messenger-types.ts
+++ b/src/tree/common/tree-messenger-types.ts
@@ -34,8 +34,19 @@ export interface CDTTreeExecuteCommand {
     value?: unknown;
 }
 
+export interface CDTTreePartialUpdate<TItem = unknown> {
+    items?: TItem[];
+}
+
 export namespace CDTTreeMessengerType {
+    /**
+     * Replace the current state with the given state.
+     */
     export const updateState: NotificationType<CDTTreeExtensionModel> = { method: 'updateState' };
+    /**
+     * Update the nodes with the given nodes.
+     */
+    export const updatePartial: NotificationType<CDTTreePartialUpdate> = { method: 'updatePartial' };
     export const ready: NotificationType<void> = { method: 'ready' };
 
     export const executeCommand: NotificationType<CDTTreeNotification<CDTTreeExecuteCommand>> = { method: 'executeCommand' };

--- a/src/tree/common/tree-messenger-types.ts
+++ b/src/tree/common/tree-messenger-types.ts
@@ -8,15 +8,7 @@
 import type { NotificationType } from 'vscode-messenger-common';
 import type { CDTTreeExtensionModel } from './tree-model-types';
 
-export interface CDTTreeNotificationContext {
-    /**
-     * If true or undefined, the tree will be resynced.
-     */
-    resync?: boolean;
-}
-
 export interface CDTTreeNotification<T> {
-    context?: CDTTreeNotificationContext;
     data: T;
 }
 

--- a/src/tree/common/tree-model-types.ts
+++ b/src/tree/common/tree-model-types.ts
@@ -1,12 +1,12 @@
-/********************************************************************************
- * Copyright (C) 2024-2025 EclipseSource, Arm Limited and others.
+/**********************************************************************************
+ * Copyright (c) 2024-2025 EclipseSource, Arm Limited and others.
  *
  * This program and the accompanying materials are made available under the
- * terms of the MIT License as outlined in the LICENSE File
- ********************************************************************************/
+ * terms of the MIT License as outlined in the LICENSE file.
+ **********************************************************************************/
 
 import { VSCodeContext } from '../../vscode/webview-types';
-import type { CDTTreeTableColumn, CDTTreeTableColumnDefinition } from './tree-table-column-types';
+import { CDTTreeTableColumn, CDTTreeTableColumnDefinition } from './tree-table-column-types';
 
 // ==== Items ====
 
@@ -82,10 +82,13 @@ export interface CDTTreeExtensionModel<TItems = unknown> {
  * The view model that is used to update the CDT tree view.
  * It is the actual model that is used to render the tree view.
  */
-export interface CDTTreeModel<TItem extends CDTTreeItemResource = CDTTreeItemResource> {
+export interface CDTTreeViewModel<TItem extends CDTTreeItemResource = CDTTreeItemResource> {
+    root: CDTTreeItem<CDTTreeItemResource>;
     items: CDTTreeItem<TItem>[];
     expandedKeys: string[];
     pinnedKeys: string[];
+    references: Record<string, CDTTreeItem<TItem> | undefined>;
+    resources: Record<string, TItem | undefined>;
 }
 
 export interface CDTTreeWebviewContext {

--- a/src/tree/common/tree-table-column-types.ts
+++ b/src/tree/common/tree-table-column-types.ts
@@ -8,21 +8,6 @@
 import type { CommandDefinition } from '../../vscode/webview-types';
 
 /**
- * A column definition for a tree table.
- * This is used to define the columns that are displayed in the tree table.
- */
-export interface CDTTreeTableColumnDefinition {
-    /**
-     * The type of the column. It can be used to show different types of columns.
-     */
-    type: string;
-    /**
-     * The field that is used to get the value for this column. See {@link CDTTreeItem.columns}.
-     */
-    field: string;
-}
-
-/**
  * A string column represents a column that displays a string value.
  */
 export interface CDTTreeTableStringColumn {
@@ -38,7 +23,48 @@ export interface CDTTreeTableStringColumn {
      * The tooltip that is displayed when hovering over the string.
      */
     tooltip?: string;
+    /**
+     * If the column is editable, this property contains the data that is used to provide proper UI for it.
+     */
+    edit?: EditableData;
 }
+
+/**
+ * An editable column represents a column that allows to edit a string value.
+ */
+export interface EditableCDTTreeTableStringColumn extends CDTTreeTableStringColumn {
+    /**
+     * Contains the data that is used to provide proper UI for it.
+     */
+    edit: EditableData;
+}
+
+export interface EditableCellData {
+    type: string;
+}
+
+export interface EditableTextData extends EditableCellData {
+    type: 'text';
+    value: string;
+}
+
+export interface EditableEnumData extends EditableCellData {
+    type: 'enum';
+    options: EditableEnumDataOption[];
+    value: string;
+}
+
+export interface EditableEnumDataOption {
+    label: string;
+    value: string;
+}
+
+export interface EditableBooleanData extends EditableCellData {
+    type: 'boolean';
+    value: '0' | '1';
+}
+
+export type EditableData = EditableTextData | EditableEnumData | EditableBooleanData;
 
 /**
  * An action column represents a column that displays multiple interactable buttons/icons.
@@ -59,3 +85,26 @@ export interface CDTTreeTableActionColumnCommand extends CommandDefinition {
 }
 
 export type CDTTreeTableColumn = CDTTreeTableStringColumn | CDTTreeTableActionColumn;
+
+export type CDTTreeTableColumnTypes = CDTTreeTableStringColumn['type'] | CDTTreeTableActionColumn['type'];
+
+/**
+ * A column definition for a tree table.
+ * This is used to define the columns that are displayed in the tree table.
+ */
+export interface CDTTreeTableColumnDefinition {
+    /**
+     * The type of the column. It can be used to show different types of columns.
+     */
+    type: CDTTreeTableColumnTypes;
+    /**
+     * The field that is used to get the value for this column. See {@link CDTTreeItem.columns}.
+     */
+    field: string;
+    /**
+     * Whether the column is resizable. Default is false.
+     * The resize handle is display on the right side.
+     * That means the column after this column is also resized.
+     */
+    resizable?: boolean;
+}

--- a/src/tree/vscode/tree-data-provider.ts
+++ b/src/tree/vscode/tree-data-provider.ts
@@ -21,16 +21,8 @@ import type { MaybePromise } from '../../base/utils';
  * are actually send to the webview to be displayed in the tree.
  */
 export interface CDTTreeDataProvider<TNode, TSerializedNode> {
-    /**
-     * An event that is fired when the tree is disposed / terminated.
-     */
     onDidTerminate: vscode.Event<CDTTreeTerminatedEvent<TNode>>;
-
-    /**
-     * An event that is fired when the tree data changes.
-     */
     onDidChangeTreeData: vscode.Event<CDTTreeNotification<TNode | TNode[] | undefined | null>>;
-
     /**
      * Get the column definitions for the tree table.
      */
@@ -42,7 +34,7 @@ export interface CDTTreeDataProvider<TNode, TSerializedNode> {
     getSerializedRoots(): MaybePromise<TSerializedNode[]>;
 
     /**
-     * Get the serialization of the given element.
+     * Get the children of the given element.
      */
     getSerializedData(element: TNode): MaybePromise<TSerializedNode>;
 }

--- a/src/tree/vscode/tree-webview-view-provider.ts
+++ b/src/tree/vscode/tree-webview-view-provider.ts
@@ -96,12 +96,18 @@ export abstract class CDTTreeWebviewViewProvider<TNode> implements vscode.Webvie
         const disposables = [
             this.dataProvider.onDidTerminate(async event => {
                 if (event.remaining > 0) {
-                    this.refresh();
+                    this.refreshFull();
                 }
             }),
             this.dataProvider.onDidChangeTreeData(async event => {
-                if (event.context?.resync !== false) {
-                    this.refresh();
+                if (event.data) {
+                    if (Array.isArray(event.data)) {
+                        await this.refreshPartial(event.data);
+                    } else {
+                        await this.refreshPartial([event.data]);
+                    }
+                } else {
+                    this.refreshFull();
                 }
             }),
             this.messenger.onNotification(CDTTreeMessengerType.ready, () => this.onReady(), { sender: participant }),
@@ -120,10 +126,10 @@ export abstract class CDTTreeWebviewViewProvider<TNode> implements vscode.Webvie
     }
 
     protected async onReady(): Promise<void> {
-        await this.refresh();
+        await this.refreshFull();
     }
 
-    protected async refresh(): Promise<void> {
+    protected async refreshFull(): Promise<void> {
         if (!this.participant) {
             return;
         }
@@ -132,6 +138,16 @@ export abstract class CDTTreeWebviewViewProvider<TNode> implements vscode.Webvie
         const items = await this.dataProvider.getSerializedRoots();
 
         this.sendNotification(CDTTreeMessengerType.updateState, { columnFields, items });
+    }
+
+    protected async refreshPartial(nodes: TNode[]): Promise<void> {
+        if (!this.participant) {
+            return;
+        }
+
+        const items = await Promise.all(nodes.map(async node => this.dataProvider.getSerializedData(node)));
+
+        this.sendNotification(CDTTreeMessengerType.updatePartial, { items });
     }
 
     public sendNotification<P>(type: NotificationType<P>, params?: P): void {

--- a/style/tree/editable-string-cell.css
+++ b/style/tree/editable-string-cell.css
@@ -1,0 +1,117 @@
+/*********************************************************************
+ * Copyright (c) 2024 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+.ant-input.text-field-cell {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+  border-radius: 0;
+  border-style: dotted;
+}
+
+.css-var-r0.ant-select-css-var {
+  --ant-control-height: auto;
+  --ant-color-text-placeholder: var(--vscode-sideBar-foreground);
+  --ant-select-show-arrow-padding-inline-end: 2em;
+  --ant-border-radius-sm: 0;
+  --ant-border-radius-lg: 0;
+  --ant-select-option-active-bg: var(--vscode-list-hoverBackground);
+  --ant-select-option-font-size: 12px;
+  --ant-select-option-selected-bg: var(--vscode-list-inactiveSelectionBackground);
+  --ant-select-option-selected-color: var(--vscode-sideBar-foreground);
+  --ant-select-option-height: auto;
+  --ant-select-option-padding: 3px 6px;
+}
+
+.enum-field-cell.ant-select-outlined:not(.ant-select-customize-input) .ant-select-selector {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+  border-radius: 0;
+  border-style: dotted;
+}
+
+.ant-select-dropdown {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+}
+
+.enum-field-cell.ant-select-outlined:not(.ant-select-customize-input) .ant-select-arrow {
+  color: var(--ant-color-text);
+}
+
+.editable-string-cell {
+  cursor: pointer;
+  display: contents;
+}
+
+.editable-string-cell .tree-label>span>span {
+  border-bottom: 1px dotted;
+}
+
+.edit-field-container,
+.editable-string-cell {
+  font-family: var(--ant-font-family-code);
+  font-style: normal;
+  filter: unset;
+  opacity: 1;
+}
+
+.ant-table-cell.value>.tree-cell {
+  font-family: var(--ant-font-family-code);
+  opacity: 0.8;
+}
+
+.edit-field-container {
+  display: contents;
+  flex-grow: 1;
+}
+
+.edit-field-container>* {
+  flex-grow: 1;
+}
+
+.edit-field-container .ant-select {
+  display: contents;
+  --ant-font-size-icon: 10px;
+}
+
+.ant-table-cell.value .tree-cell,
+.ant-table-cell.value .ant-checkbox-wrapper {
+  padding-left: 4px;
+}
+
+.ant-select-selector::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 4px;
+  /* Indent from the left */
+  width: calc(100% - 4px);
+  /* Make the dotted border span the remaining width */
+  border-bottom: 1px dotted;
+}
+
+.ant-select-selector {
+  border: 0 !important;
+}

--- a/style/tree/tree.css
+++ b/style/tree/tree.css
@@ -6,7 +6,8 @@
  ********************************************************************************/
 
 .markdown {
-    line-break: anywhere;
+    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .markdown hr {
@@ -113,5 +114,18 @@
 
 /* The horizontal scrollbar is not necessary */
 .ant-table .ant-table-tbody-virtual-scrollbar-horizontal {
+    display: none;
+}
+
+.ant-table .resizable-handle {
+    border-left: var(--vscode-sideBarSectionHeader-border) 2px solid;
+}
+
+.ant-table .resizable-handle:hover,
+.ant-table .resizable-handle:active {
+    border-color: var(--vscode-sash-hoverBorder);
+}
+
+.ant-table .ant-table-row.ant-table-row-resizing .tree-actions {
     display: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,11 @@ prettier@^3.5.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.2.tgz#d066c6053200da0234bf8fa1ef45168abed8b914"
   integrity sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==
 
+primeflex@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/primeflex/-/primeflex-3.3.1.tgz#361dddf6eb5db50d733e4cddd4b6e376a3d7bd68"
+  integrity sha512-zaOq3YvcOYytbAmKv3zYc+0VNS9Wg5d37dfxZnveKBFPr7vEIwfV5ydrpiouTft8MVW6qNjfkaQphHSnvgQbpQ==
+
 property-information@^6.0.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
@@ -2384,6 +2389,11 @@ rc-virtual-list@^3.14.2, rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     classnames "^2.2.6"
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
+
+re-resizable@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.11.2.tgz#2e8f7119ca3881d5b5aea0ffa014a80e5c1252b3"
+  integrity sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==
 
 react-is@^18.2.0:
   version "18.3.1"


### PR DESCRIPTION
Migrates new functionality implemented in the peripheral inspector.

How to test: https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/51