### PR TITLE
Revert vscode-messenger parts back to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "throttle-debounce": "5.0.2",
-        "vscode-messenger": "^0.6.0",
-        "vscode-messenger-common": "^0.6.0",
-        "vscode-messenger-webview": "^0.6.0"
+        "vscode-messenger": "^0.4.5",
+        "vscode-messenger-common": "^0.4.5",
+        "vscode-messenger-webview": "^0.4.5"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,24 +2317,24 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-vscode-messenger-common@^0.6, vscode-messenger-common@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/vscode-messenger-common/-/vscode-messenger-common-0.6.0.tgz#bfc466417ee06d558481a08b87d998ed0ac8a7dd"
-  integrity sha512-sAURSygF74TV0jEH4CnwdkDoLhy0OldxzD8lEUKMprNPkWccboGJTwKhhYRNONJPUuKK8/242sILw8EEzXQ25Q==
+vscode-messenger-common@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-common/-/vscode-messenger-common-0.4.5.tgz#bc49a25d28808db9cc322cde029fed518c8fa382"
+  integrity sha512-opA+BEYTWdy1fFC3oOw30b0zc/KEuMtw+1pOiH5fEp+BGeA5xff7omSQTZeZJSDJszM471Vi+YY/ipRdRglAlQ==
 
-vscode-messenger-webview@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/vscode-messenger-webview/-/vscode-messenger-webview-0.6.0.tgz#160dec26174a88ddbc0b636194ffa5c9317f85b4"
-  integrity sha512-KxanQpBQu/BbbX19fyxhMXm4jTirRqBhyTZxlYANsDzgNdpWTACPEQt+5earKaNpncoM4mGWkY1CYS6L8k4lbg==
+vscode-messenger-webview@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-webview/-/vscode-messenger-webview-0.4.5.tgz#89767aee50038acb6a706f5427e0fc72d5aec7f5"
+  integrity sha512-pzGB6HoTfPszMF4HQG+u5WMJ959iGLmow6ehYVTZnZjZ+phBKEBtpTYAjJSNotyUfZJ58NCdq5+ZSvMgkAuAJw==
   dependencies:
-    vscode-messenger-common "^0.6"
+    vscode-messenger-common "^0.4.5"
 
-vscode-messenger@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/vscode-messenger/-/vscode-messenger-0.6.0.tgz#ed4cff62dc387e05fcad637aa8d97db8b99768d8"
-  integrity sha512-yUbFCE4FFr1kTr/EaZ1zSjucbs4yCCe8oVS/+dkeaFnLyNKhPQ2xWEM+YdElvdJuJrhmfIwzu4v5qTj79gJWOg==
+vscode-messenger@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger/-/vscode-messenger-0.4.5.tgz#decf7475568ce3a3912479c29ff1e6eac61c7470"
+  integrity sha512-a6e54dpPRi/ITmVex49LGU6YXlqcuxGPlDPauvZig20G1D1/QD2E8GfhtvlTj3ml5aU/QV3LHghyepq3riy7sw==
   dependencies:
-    vscode-messenger-common "^0.6"
+    vscode-messenger-common "^0.4.5"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Revert the following vscode-messenger parts back to v0.4.5. There seem to be changes which stop the Peripheral Inspector window to no longer update:
```
        "vscode-messenger": "^0.4.5",
        "vscode-messenger-common": "^0.4.5",
        "vscode-messenger-webview": "^0.4.5"
```

To be addressed with a bit more focus on debugging the problems in #11 