### PR TITLE
v0.1.0 Release Preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.1.0
+- Updates [Tree](./src/tree/README.md) component:
+    - Adds optional support for search in data backend implementation.
+        - Configures search behavior through `search.mode` in `CDTTreeProps`.
+        - Adds `searchChanged` notification from webview to host.
+        - Increases search text debounce from 300ms to 600ms.
+- chore: Updated GitHub workflows to node 22.
+- chore: Updated dependencies
+
 ## 0.0.1
 - Initial release of this package.
 - Adds [Tree](./src/tree/README.md) component.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2024-2025 Arm Limited and EclipseSource
+Copyright 2024-2026 Arm Limited and EclipseSource, and others
 Copyright 2017-2023 Marcel Ball and Arm Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eclipse-cdt-cloud/vscode-ui-components",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "description": "UI Components for Visual Studio Code Extensions",
     "repository": "https://github.com/eclipse-cdt-cloud/vscode-ui-components",
     "license": "MIT",


### PR DESCRIPTION
* Bump package version to 0.1.0.
* Update license text to include `and others`.
* Update CHANGELOG.